### PR TITLE
Inline all .toc's children: avoids line breaks on table of contents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "html_email_creator",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "html_email_creator",
-            "version": "1.0.13",
+            "version": "1.0.14",
             "dependencies": {
                 "16": "^0.0.2",
                 "@testing-library/jest-dom": "^5.16.5",

--- a/src/util.js
+++ b/src/util.js
@@ -64,7 +64,7 @@ const generateTOC = (html) => {
     if (ignore && header.compareDocumentPosition(ignore) === 2) {
       ignore.remove();
     } else {
-      let href = header.innerText.replaceAll(' ', '-').toLowerCase();
+      let href = header.innerText.replaceAll(/\s/g, '-').toLowerCase();
       let text = (i) + '. ' + header.innerHTML;
       i++;
       menu.appendChild(createAnchorEl(href, text));
@@ -79,8 +79,24 @@ const createAnchorEl = (href, text) => {
   let a = document.createElement('a');
   a.href = `#${href}`;
   a.innerHTML = text;
+  console.log(a);
+  a.firstElementChild && inlineChildren(a.firstElementChild);
   a.className = 'toc';
   return a;
+}
+
+/**
+ * Adds `display: inline` to all children of a given node recursively
+ * @param node HTMLelement
+ */
+const inlineChildren = (node) => {
+  if (node.children.length) {
+      Array.from(node.children).forEach(child => {
+        inlineChildren(child);
+      })
+  }
+  
+  node.style.display = 'inline';
 }
 
 const escapeRegExp = (string) => {


### PR DESCRIPTION
A veces, al copiar un título de un documento de word y pegarlo en un Heading, el EDB inserta algo de HTML en lugar de insertar el texto solo. Está un poco fea la solución pero fue lo que me salió.